### PR TITLE
Add support for .map files as JSON (fixes #13)

### DIFF
--- a/src/Servant/Static/TH/Internal/Mime.hs
+++ b/src/Servant/Static/TH/Internal/Mime.hs
@@ -108,6 +108,7 @@ extensionMimeTypeMap =
   , ("json", MimeTypeInfo [t|JSON|] [t|ByteString|] byteStringToExp)
   , ("xml",  MimeTypeInfo [t|XML|]  [t|ByteString|] byteStringToExp)
   , ("gexf", MimeTypeInfo [t|GEXF|] [t|ByteString|] byteStringToExp)
+  , ("map",  MimeTypeInfo [t|JSON|] [t|ByteString|] byteStringToExp)
   ]
 
 -- | Just like 'extensionToMimeTypeInfo', but throw an error using 'fail' if


### PR DESCRIPTION
This change addresses the error you get if you try to serve an app with `.map` files, e.g. generated by webpack/react. Reference for mimetype: https://stackoverflow.com/questions/19911929/what-mime-type-should-i-use-for-javascript-source-map-files